### PR TITLE
Add audit logs, security script, and Windows setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Total estimated duration: ~8–9 weeks with one full-time developer or a small t
 ## Contributing
 
 1. Clone the repository.
-2. Create a virtual environment and install dependencies: `pip install -r requirements.txt`.
+2. On Windows, run `setup.cmd` to create a virtual environment and install dependencies automatically. Linux/macOS users can run `pip install -r requirements.txt`.
 3. Copy `.env.example` to `.env` and update the credentials for MySQL and IMAP.
 4. Initialize the database tables: `python -c 'from app import db; db.create_all()'`.
 5. In one terminal run the email collector: `python collector.py`.

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, jsonify, request, render_template
 from flask_sqlalchemy import SQLAlchemy
 from dotenv import load_dotenv
+from datetime import datetime
 import os
 
 load_dotenv()
@@ -23,6 +24,19 @@ class EvaluationForm(db.Model):
     signed_pdf_path = db.Column(db.String(255))
 
 
+class AuditLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    eval_id = db.Column(db.Integer)
+    action = db.Column(db.String(50))
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+def log_action(eval_id, action):
+    log = AuditLog(eval_id=eval_id, action=action)
+    db.session.add(log)
+    db.session.commit()
+
+
 @app.route('/')
 def index():
     forms = EvaluationForm.query.all()
@@ -35,6 +49,7 @@ def review(eval_id):
     form = EvaluationForm.query.get_or_404(eval_id)
     form.status = 'Signed'
     db.session.commit()
+    log_action(eval_id, 'Signed')
     return jsonify({'ok': True})
 
 

--- a/collector.py
+++ b/collector.py
@@ -4,7 +4,7 @@ import uuid
 import os
 from pathlib import Path
 from dotenv import load_dotenv
-from db import get_db
+from app import app, db, EvaluationForm, log_action
 
 load_dotenv()
 
@@ -21,8 +21,18 @@ def parse_subject(subject):
 
 
 def create_eval_record(path, vessel, quarter, year, rank):
-    # placeholder for DB insert logic
-    pass
+    with app.app_context():
+        form = EvaluationForm(
+            seafarer_id=0,
+            vessel_id=0,
+            quarter=quarter,
+            year=int(year),
+            pdf_path=str(path),
+            status='Received'
+        )
+        db.session.add(form)
+        db.session.commit()
+        log_action(form.id, 'Received')
 
 
 def fetch_new_emails():

--- a/setup.cmd
+++ b/setup.cmd
@@ -1,0 +1,18 @@
+@echo off
+REM Setup script for Windows/XAMPP
+
+IF NOT EXIST venv (
+    python -m venv venv
+)
+
+call venv\Scripts\activate
+
+pip install --upgrade pip
+pip install -r requirements.txt
+
+ECHO.
+ECHO Environment ready. To start the collector run:
+ECHO    python collector.py
+ECHO To start the web server run:
+ECHO    flask --app app run
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,18 @@
             <td>{{ f.status }}</td>
         </tr>
         {% endfor %}
-    </table>
+</table>
+    <script>
+        document.addEventListener('contextmenu', function(e) {
+            e.preventDefault();
+        });
+        document.addEventListener('keydown', function(e) {
+            if (e.keyCode === 123 ||
+                (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'i') ||
+                (e.ctrlKey && e.key.toLowerCase() === 'u')) {
+                e.preventDefault();
+            }
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- secure dashboard page by blocking right-click and common view-source shortcuts
- introduce AuditLog model for tracking evaluation history
- create setup.cmd to easily install dependencies
- log state changes when signing evaluations or receiving email
- document setup.cmd usage

## Testing
- `python -m py_compile app.py collector.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854025d924483259ef8e32f843ff2ed